### PR TITLE
remove deprication warning

### DIFF
--- a/rust_code_obfuscator_core/src/utils.rs
+++ b/rust_code_obfuscator_core/src/utils.rs
@@ -1,6 +1,6 @@
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 
 pub fn generate_obf_suffix() -> u32 {
-    let mut rng = thread_rng();
-    rng.gen_range(1000..=9999)
+    let mut rng = rng();
+    rng.random_range(1000..=9999)
 }


### PR DESCRIPTION
What this PR does:
This PR modifies the `generate_obf_suffix` function to use a different function for generating random numbers.

Why this change is needed:
To update the function to be compatible with the current version of the `rand` crate.

Related issue:
Closes #45