### PR TITLE
add tests for crypto and utils

### DIFF
--- a/rust_code_obfuscator_core/src/crypto.rs
+++ b/rust_code_obfuscator_core/src/crypto.rs
@@ -94,4 +94,21 @@ mod tests {
 
         assert_eq!(data_to_encrypt, decrypted);
     }
+
+    #[test]
+    #[should_panic]
+    fn decrypt_with_wrong_key_should_panic() {
+        let key_ok: [u8; 32] = core::array::from_fn(|i| i as u8);
+        let key_bad: [u8; 32] = [0u8; 32];
+        let (ct, nonce) = encrypt_string("secret", &key_ok);
+        let _ = decrypt_string(&ct, &nonce, &key_bad); // expected panic
+    }
+
+    #[test]
+    fn encrypt_and_decrypt_unicode() {
+        let key: [u8; 32] = core::array::from_fn(|i| i as u8);
+        let s = "café Καλημέρα — 数据";
+        let (ct, nonce) = encrypt_string(s, &key);
+        assert_eq!(s, decrypt_string(&ct, &nonce, &key));
+    }
 }

--- a/rust_code_obfuscator_core/src/utils.rs
+++ b/rust_code_obfuscator_core/src/utils.rs
@@ -1,6 +1,50 @@
 use rand::{rng, Rng};
 
+const MIN_SUFF_VALUE: u32 = 1000;
+const MAX_SUFF_VALUE: u32 = 9999;
+
 pub fn generate_obf_suffix() -> u32 {
     let mut rng = rng();
-    rng.random_range(1000..=9999)
+    let num: u32 = rng.random_range(MIN_SUFF_VALUE..=MAX_SUFF_VALUE);
+    num
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_suffix_len() -> usize {
+        let len_1 = MIN_SUFF_VALUE.to_string().len();
+        let len_2 = MAX_SUFF_VALUE.to_string().len();
+        if len_1 != len_2 {
+            panic!(
+                "
+            The lengths of the boundary values are no longer the same!
+            Change one of the values or change the test."
+            );
+        }
+        len_1
+    }
+
+    #[test]
+    fn check_generate_obf_suffix() {
+        let suf = generate_obf_suffix();
+
+        let expected_suff_len = get_suffix_len();
+
+        assert_eq!(
+            suf.to_string().len(),
+            expected_suff_len,
+            "Generated suffix must be {} digits long, received {}",
+            expected_suff_len.to_string(),
+            suf.to_string()
+        );
+        assert!(
+            (MIN_SUFF_VALUE..=MAX_SUFF_VALUE).contains(&suf),
+            "Numeric value must be between {} and {}, received {}",
+            MIN_SUFF_VALUE,
+            MAX_SUFF_VALUE,
+            suf
+        );
+    }
 }


### PR DESCRIPTION
What this PR does:
- adds more tests for the `rust_code_obfuscator_core::crypto` mod
- adds tests for the `rust_code_obfuscator_core::utils` mod
- assign magic numbers to the constants in the `rust_code_obfuscator_core::utils` mod

Why this change is needed:
More tests, more

Part of ongoing work for #3