### PR TITLE
add test for errors mod

### DIFF
--- a/rust_code_obfuscator_core/src/errors.rs
+++ b/rust_code_obfuscator_core/src/errors.rs
@@ -18,3 +18,37 @@ impl fmt::Display for ObfuscatorError {
 }
 
 impl error::Error for ObfuscatorError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_encryption_error() {
+        let encryption_err = ObfuscatorError::EncryptionError;
+
+        let displayed = encryption_err.to_string();
+
+        assert! {
+            displayed.contains("Encryption failed :(")
+        }
+    }
+
+    #[test]
+    fn display_inv_file_ext() {
+        let test_file_path = "./test.txt";
+
+        let inv_file_ext_err = ObfuscatorError::InvalidFileExtension {
+            path: PathBuf::from(test_file_path),
+        };
+
+        let displayed = inv_file_ext_err.to_string();
+
+        assert! {
+            displayed.contains(test_file_path),
+            "Expected output contains: '{}',got: {}",
+            test_file_path,
+            displayed
+        }
+    }
+}


### PR DESCRIPTION
What this PR does:
- adds unit tests for the `rust_code_obfuscator_core::errors` mod

Why this change is needed:
To show I'm alive